### PR TITLE
feat: add jest moduleNameMapper for element-ui&main

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,13 @@
 module.exports = {
-  testEnvironment: "jsdom",
+  testEnvironment: 'jsdom',
   transform: {
-    "^.+\\.vue$": "vue-jest",
-    "^.+\\js$": "babel-jest",
+    '^.+\\.vue$': 'vue-jest',
+    '^.+\\js$': 'babel-jest'
   },
-  moduleFileExtensions: ["vue", "js", "json", "jsx", "ts", "tsx", "node"],
-  testMatch: ["**/tests/?(*.)+(test).[jt]s?(x)"],
-};
+  moduleFileExtensions: ['vue', 'js', 'json', 'jsx', 'ts', 'tsx', 'node'],
+  testMatch: ['**/tests/?(*.)+(test).[jt]s?(x)'],
+  moduleNameMapper: {
+    '^element-ui(.*)$': '<rootDir>$1',
+    '^main(.*)$': '<rootDir>/src$1'
+  }
+}


### PR DESCRIPTION
配置jest.config.js 添加moduleNameMapper 可以正常在jest中使用路径element-ui和main两个路径别名了
