### PR TITLE
fix: #95

### DIFF
--- a/build/webpack.demo.js
+++ b/build/webpack.demo.js
@@ -6,7 +6,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const ProgressBarPlugin = require('progress-bar-webpack-plugin')
 const { VueLoaderPlugin } = require('vue-loader')
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin')
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
+const TerserPlugin = require('terser-webpack-plugin')
 
 const config = require('./config')
 
@@ -142,7 +142,7 @@ if (isProd) {
     })
   )
   webpackConfig.optimization.minimizer.push(
-    new UglifyJsPlugin({
+    new TerserPlugin({
       cache: true,
       parallel: true,
       sourceMap: false

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "deepmerge": "^1.2.0",
     "normalize-wheel": "^1.0.1",
     "resize-observer-polyfill": "^1.5.0",
+    "terser-webpack-plugin": "^4.1.0",
     "throttle-debounce": "^1.0.1"
   },
   "peerDependencies": {
@@ -168,7 +169,6 @@
     "style-loader": "^0.23.1",
     "transliteration": "^1.1.11",
     "typescript": "^3.7.5",
-    "uglifyjs-webpack-plugin": "^2.1.1",
     "uppercamelcase": "^1.1.0",
     "url-loader": "^1.0.1",
     "vue": "^3.0.0-rc.4",


### PR DESCRIPTION
解决npm run deploy:build 报错

问题原因:
1，是UglifyJS不支持ES6的语法。
2，发现uglifyjs-webpack-plugin 2.0版本的Release日志中，明确提示重新切换回到uglify-js，因为uglify-es被废弃了，如果需要ES6代码压缩，请使用terser-webpack-plugin

解决方案：
使用 terser-webpack-plugin 替换 uglifyjs-webpack-plugin 进行代码压缩