### PR TITLE
fix: checkboxGroupDisabled中应该直接获取elForm和elFormItem的disabled属性

### DIFF
--- a/packages/checkbox-group/CheckboxGroup.vue
+++ b/packages/checkbox-group/CheckboxGroup.vue
@@ -39,9 +39,7 @@ export default {
     })
 
     const checkboxGroupDisabled = computed(() => {
-      return (
-        props.disabled || elFormItem.props.disabled || elForm.props.disabled
-      )
+      return props.disabled || elFormItem.disabled || elForm.disabled
     })
 
     watch(props.modelValue, (v) => {


### PR DESCRIPTION
checkboxGroupDisabled中应该直接获取elForm和elFormItem的disabled属性，目前这样访问获取不到报错了
